### PR TITLE
Allocate a generous buffer for filenames -- fixes buffer overflow with long filenames/filepaths

### DIFF
--- a/plot.c
+++ b/plot.c
@@ -587,10 +587,10 @@ int main(int argc, char **argv) {
 
 	mkdir(outputdir, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IROTH);
 
-	char name[100];
-	char finalname[100];
-	sprintf(name, "%s%llu_%llu_%u_%u.plotting", outputdir, addr, startnonce, nonces, nonces);
-	sprintf(finalname, "%s%llu_%llu_%u_%u", outputdir, addr, startnonce, nonces, nonces);
+	char name[4096];
+	char finalname[4096];
+	snprintf(name, sizeof(name), "%s%llu_%llu_%u_%u.plotting", outputdir, addr, startnonce, nonces, nonces);
+	snprintf(finalname, sizeof(filename), "%s%llu_%llu_%u_%u", outputdir, addr, startnonce, nonces, nonces);
 
 	if ( fileexists(name) ) {
 		unlink(name);


### PR DESCRIPTION
This should fix buffer overflow crashes when long file paths are used.